### PR TITLE
[FEAT] 권한별 마이페이지 라우팅

### DIFF
--- a/woori-zip/src/app/api/mypage/MypageAPI.js
+++ b/woori-zip/src/app/api/mypage/MypageAPI.js
@@ -2,7 +2,7 @@
 import { instance } from "../instance";
 
 export const fetchMemberInfo = async () => {
-    return await instance(`members/info`, {
+    return await instance(`members/profile`, {
       method: 'GET',
       credentials: 'include',
     });

--- a/woori-zip/src/auth.js
+++ b/woori-zip/src/auth.js
@@ -37,11 +37,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
         return response.data;
       },
-      profile(accessToken, name) {
+      profile(accessToken, name, role) {
         return {
           id: name,
           username: name,
           accessToken,
+          role,
         };
       },
     }),
@@ -104,6 +105,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         session.user.accessToken = token.user.accessToken;
         session.user.name = token.user.name;
         session.user.expires_at = token.expires_at;
+        session.user.role = token.user.role;
         session.error = token.error;
       }
       return session;

--- a/woori-zip/src/components/layout/Header/Header.js
+++ b/woori-zip/src/components/layout/Header/Header.js
@@ -21,13 +21,30 @@ export default function Header() {
   };
 
   const handleProfileClick = () => {
-    router.push('/mypage');
+    if (data?.user?.role) {
+      switch (data.user.role) {
+        case 'MEMBER':
+          router.push('/mypage');          
+          break;
+        case 'AGENT':
+          router.push('/realestate');
+          break;
+        case 'ADMIN':
+          router.push('/manager');
+          break;
+        default:
+          console.warn('Unknown role:', data.user.role);
+      }
+    } else {
+      console.error('User role is not defined');
+    }
     setIsDropdownOpen(false); // Close dropdown after navigation
   };
 
   useEffect(() => {
     if (status === 'authenticated') {
       console.log('로그인 상태 확인:', data);
+      console.log("확인이다용", data.user?.role);
     }
   }, [status, data]);
 


### PR DESCRIPTION
## 📝 Description
- 세션에 role 추가하여 권한별 마이페이지 라우팅

## #️⃣ Issue
- closed #192 

## 📷 Screen Shot
- npm run build
![image](https://github.com/user-attachments/assets/e8702e1f-71de-4be8-b508-b3010c9f64a4)


- 실행 화면
- MEMBER
![image](https://github.com/user-attachments/assets/160d9909-ae9c-45f1-9d18-72afdd502b44)
- AGENT
![image](https://github.com/user-attachments/assets/d4de3a90-1935-4045-b991-5ae749a09494)
- ADMIN
![image](https://github.com/user-attachments/assets/c70ad468-3f42-4403-a843-12ccba0f3a87)

## 💬 To Reviewers
- 
